### PR TITLE
feat: enables estimates for custom number of blocks

### DIFF
--- a/lib/api/lib.api
+++ b/lib/api/lib.api
@@ -38,7 +38,8 @@ public final class xyz/block/augur/FeeEstimator {
 	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/time/Duration;)V
 	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/time/Duration;Ljava/time/Duration;)V
 	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/time/Duration;Ljava/time/Duration;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun calculateEstimates (Ljava/util/List;)Lxyz/block/augur/FeeEstimate;
+	public final fun calculateEstimates (Ljava/util/List;Ljava/lang/Double;)Lxyz/block/augur/FeeEstimate;
+	public static synthetic fun calculateEstimates$default (Lxyz/block/augur/FeeEstimator;Ljava/util/List;Ljava/lang/Double;ILjava/lang/Object;)Lxyz/block/augur/FeeEstimate;
 	public final fun configure (Ljava/util/List;Ljava/util/List;Ljava/time/Duration;Ljava/time/Duration;)Lxyz/block/augur/FeeEstimator;
 	public static synthetic fun configure$default (Lxyz/block/augur/FeeEstimator;Ljava/util/List;Ljava/util/List;Ljava/time/Duration;Ljava/time/Duration;ILjava/lang/Object;)Lxyz/block/augur/FeeEstimator;
 }

--- a/lib/src/test/kotlin/xyz/block/augur/FeeEstimatorTest.kt
+++ b/lib/src/test/kotlin/xyz/block/augur/FeeEstimatorTest.kt
@@ -22,6 +22,7 @@ import java.time.Duration
 import java.time.Instant
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.assertFailsWith
 
 class FeeEstimatorTest {
   private val feeEstimator = FeeEstimator()
@@ -303,5 +304,28 @@ class FeeEstimatorTest {
     // Test that available confidence levels are returned in ascending order
     val availableConfidenceLevels = estimate.getAvailableConfidenceLevels()
     assertEquals(listOf(0.2, 0.5, 0.8), availableConfidenceLevels)
+  }
+
+  @Test
+  fun `test when numOfBlocks specified we get same value for the default block targets`() {
+    val snapshots =
+      TestUtils.createSnapshotSequence(
+        blockCount = 5,
+        snapshotsPerBlock = 3,
+      )
+
+    val estimate = feeEstimator.calculateEstimates(snapshots)
+    FeeEstimator.DEFAULT_BLOCK_TARGETS.forEach { target ->
+      val estimateForTarget = feeEstimator.calculateEstimates(snapshots, target)
+      assertEquals(estimate.estimates[target.toInt()], estimateForTarget.estimates[target.toInt()])
+    }
+  }
+
+  @Test
+  fun `test calculateEstimates throws if numOfBlocks less than 3`() {
+    val snapshots = TestUtils.createSnapshotSequence(blockCount = 5, snapshotsPerBlock = 3)
+    assertFailsWith<IllegalArgumentException> {
+      feeEstimator.calculateEstimates(snapshots, numOfBlocks = 2.0)
+    }
   }
 }


### PR DESCRIPTION
This change adds a new function that allows us to input the estimate we want for a custom number of blocks so that we are not limited to what we initially put for the `blockTargets`

related PR for reference implementation https://github.com/block/bitcoin-augur-reference/pull/3