### PR TITLE
make it easier to use local augur in reference implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ val feeEstimator = FeeEstimator()
 
 // Create a mempool snapshot from current transactions
 val mempoolSnapshot = MempoolSnapshot.fromMempoolTransactions(
-    transactions = currentMempoolTransactions.map { 
+    transactions = currentMempoolTransactions.map {
         MempoolTransaction(
             weight = it.weight.toLong(),
             fee = it.baseFee // in satoshis
@@ -84,7 +84,7 @@ val probabilities = sixBlockTarget?.probabilities
 val customFeeEstimator = FeeEstimator(
     // Custom probability levels (confidence)
     probabilities = listOf(0.1, 0.25, 0.5, 0.75, 0.9, 0.99),
-    
+
     // Custom block targets
     blockTargets = listOf(1.0, 2.0, 3.0, 6.0, 12.0, 24.0, 48.0, 72.0)
 )
@@ -99,6 +99,11 @@ This library focuses solely on fee estimation based on mempool data. You are res
 3. Providing historical snapshots to the fee estimator
 
 See our [reference implementation](https://github.com/block/bitcoin-augur-reference) for a complete example of integration with Bitcoin Core and implementing a persistence layer.
+
+If you'd like to use a local version of Augur within your reference implementation:
+ - Copy the file `lib/build/libs/augur.jar` into the reference implementation `app/libs` directory.
+ - Change
+`implementation(libs.augur)` to `implementation(files("libs/augur.jar"))` in the `app/build.gradle.kts` [file](https://github.com/block/bitcoin-augur-reference/blob/main/app/build.gradle.kts).
 
 ## How It Works
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ mavenPublishGradlePlugin = "0.31.0"
 dependencyAnalysis = "2.13.0"
 binaryCompatibilityValidator = "0.17.0"
 spotless = "7.0.2"
+shadow = "8.1.1"
 
 [libraries]
 # Core dependencies
@@ -38,3 +39,4 @@ mavenPublishGradlePlugin = { id = "com.vanniktech.maven.publish.base", version.r
 dependencyAnalysis = { id = "com.autonomousapps.dependency-analysis", version.ref = "dependencyAnalysis" }
 binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "binaryCompatibilityValidator" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
+shadow = { id = "com.github.johnrengelman.shadow", version.ref = "shadow" }

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     `java-library`
     id("org.jetbrains.dokka")
     id("com.diffplug.spotless")
+    alias(libs.plugins.shadow)
 }
 
 group = "xyz.block"
@@ -44,6 +45,9 @@ dependencies {
     implementation(libs.guava)
     implementation(libs.viktor)
 
+    // SLF4J implementation for Viktor dependency
+    implementation("org.slf4j:slf4j-simple:1.7.36")
+
     // Testing dependencies
     testImplementation(kotlin("test"))
     testImplementation(libs.junit.jupiter.engine)
@@ -51,6 +55,16 @@ dependencies {
     testImplementation(libs.mockk)
 
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.build {
+  dependsOn(tasks.shadowJar)
+}
+
+tasks.shadowJar {
+  archiveBaseName.set("augur")
+  archiveClassifier.set("") // No "-all" suffix
+  mergeServiceFiles()
 }
 
 tasks.test {
@@ -66,7 +80,7 @@ dokka {
         moduleName.set("augur")
         includes.from("Module.md")
         jdkVersion.set(11)
-        
+
         sourceLink {
             localDirectory.set(file("src/main/kotlin"))
             remoteUrl("https://github.com/block/bitcoin-augur/blob/main/lib/src/main/kotlin")


### PR DESCRIPTION
Was having difficulty running a local version of Augur in the reference implementation due to dependencies not getting included in the jar:
```
NoClassDefFoundError: org/jetbrains/bio/viktor/F64Array
...
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder"
```
The changes in this PR fixed the issues. 