### PR TITLE
Harden bucket index handling with helpers and bounds checks

### DIFF
--- a/lib/src/main/kotlin/xyz/block/augur/internal/BucketCreator.kt
+++ b/lib/src/main/kotlin/xyz/block/augur/internal/BucketCreator.kt
@@ -44,6 +44,17 @@ internal object BucketCreator {
   const val BUCKET_ARRAY_SIZE = BUCKET_MAX - BUCKET_MIN + 1
 
   /**
+   * Converts a bucket index (BUCKET_MIN..BUCKET_MAX) to the corresponding array position.
+   * Buckets are stored in reverse order so that the highest fee rate (BUCKET_MAX) is at index 0.
+   */
+  fun toArrayIndex(bucket: Int): Int = BUCKET_MAX - bucket
+
+  /**
+   * Converts an array position back to the original bucket index.
+   */
+  fun toBucketIndex(arrayIndex: Int): Int = BUCKET_MAX - arrayIndex
+
+  /**
    * Creates a bucket map from fee and weight pairs where the key is the bucket index
    * and the value is the sum of the weights at that fee rate, normalized to a one block duration.
    */

--- a/lib/src/main/kotlin/xyz/block/augur/internal/FeeEstimatesCalculator.kt
+++ b/lib/src/main/kotlin/xyz/block/augur/internal/FeeEstimatesCalculator.kt
@@ -176,7 +176,7 @@ internal class FeeEstimatesCalculator(
     return when (index) {
       -2 -> BUCKET_MIN // all weights are zero so we can use the cheapest fee rate
       -1 -> BUCKET_MAX + 1 // return null
-      else -> BUCKET_MAX - index
+      else -> BucketCreator.toBucketIndex(index)
     }
   }
 

--- a/lib/src/main/kotlin/xyz/block/augur/internal/MempoolSnapshotF64Array.kt
+++ b/lib/src/main/kotlin/xyz/block/augur/internal/MempoolSnapshotF64Array.kt
@@ -38,9 +38,9 @@ internal data class MempoolSnapshotF64Array(
       snapshot.bucketedWeights.forEach { (bucket, weight) ->
         // Remove buckets below BUCKET_MIN (~0.1 sat/vB; round() admits ~0.0998 here,
         // which converts back to ~0.10026 sat/vB so we never emit a sub-0.1 estimate)
-        if (bucket >= BucketCreator.BUCKET_MIN) {
+        if (bucket in BucketCreator.BUCKET_MIN..BucketCreator.BUCKET_MAX) {
           // Inserting into reverse order will allow us to mine the highest fee rate buckets first
-          feeRateBuckets[BucketCreator.BUCKET_MAX - bucket] = weight.toDouble()
+          feeRateBuckets[BucketCreator.toArrayIndex(bucket)] = weight.toDouble()
         }
       }
 

--- a/lib/src/test/kotlin/xyz/block/augur/internal/BucketCreatorTest.kt
+++ b/lib/src/test/kotlin/xyz/block/augur/internal/BucketCreatorTest.kt
@@ -140,6 +140,11 @@ class BucketCreatorTest {
   }
 
   @Test
+  fun `test BUCKET_MIN matches ln(0_1) times 100 rounded`() {
+    assertEquals((ln(0.1) * 100).roundToInt(), BucketCreator.BUCKET_MIN)
+  }
+
+  @Test
   fun `test createFeeRateBuckets with very low fee rates`() {
     // Test 0.1 sat/vB minimum (Bitcoin Core 29.1/30.0+)
     val transactions =

--- a/lib/src/test/kotlin/xyz/block/augur/internal/MempoolSnapshotF64ArrayTest.kt
+++ b/lib/src/test/kotlin/xyz/block/augur/internal/MempoolSnapshotF64ArrayTest.kt
@@ -43,7 +43,7 @@ class MempoolSnapshotF64ArrayTest {
     val result = MempoolSnapshotF64Array.fromMempoolSnapshot(snapshot)
 
     assertEquals(BucketCreator.BUCKET_ARRAY_SIZE, result.buckets.length)
-    val validIndex = BucketCreator.BUCKET_MAX - validBucket
+    val validIndex = BucketCreator.toArrayIndex(validBucket)
     assertEquals(600.0, result.buckets[validIndex])
 
     var totalWeight = 0.0
@@ -84,5 +84,31 @@ class MempoolSnapshotF64ArrayTest {
       totalWeight += result.buckets[i]
     }
     assertEquals(500.0, totalWeight)
+  }
+
+  @Test
+  fun `fromMempoolSnapshot drops buckets above BUCKET_MAX`() {
+    val oversizedBucket = BucketCreator.BUCKET_MAX + 1
+    val validBucket = BucketCreator.BUCKET_MAX
+
+    val snapshot =
+      MempoolSnapshot(
+        blockHeight = 100,
+        timestamp = Instant.now(),
+        bucketedWeights = mapOf(
+          oversizedBucket to 1000L,
+          validBucket to 500L,
+        ),
+      )
+
+    val result = MempoolSnapshotF64Array.fromMempoolSnapshot(snapshot)
+
+    // Only the valid bucket's weight should be included
+    var totalWeight = 0.0
+    for (i in 0 until result.buckets.length) {
+      totalWeight += result.buckets[i]
+    }
+    assertEquals(500.0, totalWeight)
+    assertEquals(500.0, result.buckets[BucketCreator.toArrayIndex(validBucket)])
   }
 }


### PR DESCRIPTION
## Summary
- Add `toArrayIndex`/`toBucketIndex` helpers to `BucketCreator` to replace raw `BUCKET_MAX - bucket` arithmetic scattered across the codebase
- Guard against out-of-bounds bucket indices from the public `MempoolSnapshot` API by checking both lower and upper bounds (`BUCKET_MIN..BUCKET_MAX`)
- Assert that `BUCKET_MIN` matches its documented derivation (`round(ln(0.1) * 100)`)

## Context
Follow-up hardening from PR #10 (sub-1 sat/vB support). The previous PR only guarded `bucket >= BUCKET_MIN`, leaving the upper bound unchecked — a caller using the public `MempoolSnapshot` constructor with a bucket > `BUCKET_MAX` would cause a negative array index crash.

## Test plan
- [x] `test BUCKET_MIN matches ln(0_1) times 100 rounded` — validates constant derivation
- [x] `fromMempoolSnapshot drops buckets above BUCKET_MAX` — confirms oversized buckets are silently dropped
- [x] All existing tests pass (27 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)